### PR TITLE
Fix PetAI behavior index and AnimalCages domain prefix

### DIFF
--- a/feverstonewilds/resources/assets/feverstonewilds/patches/config/animalcagesconfig.json
+++ b/feverstonewilds/resources/assets/feverstonewilds/patches/config/animalcagesconfig.json
@@ -2,7 +2,7 @@
     {
         "op": "addeach",
         "path": "/smallCatchableEntities/-",
-        "file": "config/defaultconfig.json",
+        "file": "animalcages:config/defaultconfig.json",
         "value": [
             {
                 "name": "direwolf-pup",
@@ -39,7 +39,7 @@
     {
         "op": "addeach",
         "path": "/mediumCatchableEntities/-",
-        "file": "config/defaultconfig.json",
+        "file": "animalcages:config/defaultconfig.json",
         "value": [
             {
                 "name": "bison-calf-*",

--- a/feverstonewilds/resources/assets/feverstonewilds/patches/entities/direwolfpetaicompat.json
+++ b/feverstonewilds/resources/assets/feverstonewilds/patches/entities/direwolfpetaicompat.json
@@ -248,7 +248,7 @@
     },
     {
         "op": "addeach",
-        "path": "/server/behaviors/15/aitasks/0",
+        "path": "/server/behaviors/16/aitasks/0",
         "value": [
                     {
                         "code": "petmeleeattack",


### PR DESCRIPTION
## Bug fixes for Vintage Story 1.22

Two JSON patch errors at server startup, both confirmed fixed.

### Fix 1 — Wrong behavior index in `direwolfpetaicompat.json`

**Error:**
```
[Server Error] Patch 13 (target: feverstonewilds:entities/land/tame-direwolf.json)
in feverstonewilds:patches/entities/direwolfpetaicompat.json failed because supplied
path /server/behaviors/15/aitasks/0 is invalid: The json path
/server/behaviors/15/aitasks/0 was not found. Could traverse until
/server/behaviors/15, but then 'aitasks' does not exist.
```

**Cause:** index 15 is the `emotionstates` behavior (field `states`); the `taskai` behavior that owns `aitasks` is at index **16**.

**Fix:** `15` → `16`

**Impact without this fix:** the tamed dire wolf gets no combat AI tasks injected (petmeleeattack, petseekentity, followmaster, stay, simplecommand) and behaves passively.

---

### Fix 2 — Missing domain prefix in `animalcagesconfig.json`

**Error:**
```
[Server Error] Patch 0 in feverstonewilds:patches/config/animalcagesconfig.json:
File feverstonewilds:config/defaultconfig.json not found
[Server Error] Patch 1 in feverstonewilds:patches/config/animalcagesconfig.json:
File feverstonewilds:config/defaultconfig.json not found
```

**Cause:** `"file": "config/defaultconfig.json"` resolves to the `feverstonewilds` domain by default, but the file belongs to the `animalcages` mod.

**Fix:** `config/defaultconfig.json` → `animalcages:config/defaultconfig.json` (both patches)